### PR TITLE
Remove nonexistant HL2 anims & add some unused anims

### DIFF
--- a/2-LISTS/Animlist.md
+++ b/2-LISTS/Animlist.md
@@ -256,10 +256,10 @@ Some of these may not function ingame or are inaccessible through normal means!
 
 Animation | Description
 --------- | -----------
-HintMessageLower |
-HintMessageRaise |
-HudReplayReminderIn |
-HudReplayReminderIn2 |
-eventHudCartAlarmPulseStop |
-HudTournament_DoorsCloseEndRound | runs if "competitive_victory" is the current Tournament mode state
-TimerFlash |
+HintMessageLower | Potential remnants of HL2? used for the history of picked up weapons
+HintMessageRaise | Same as above
+HudReplayReminderIn | Potential remnant from when replays were enabled on valve servers?
+HudReplayReminderIn2 | Same as above
+eventHudCartAlarmPulseStop | Misspelling of `HudCartAlarmPulseStop`, which is never run due to this.
+HudTournament_DoorsCloseEndRound | Runs if the current Tournament mode state is "competitive_victory"
+TimerFlash | Runs whenever the timer is restarted or paused?

--- a/2-LISTS/Animlist.md
+++ b/2-LISTS/Animlist.md
@@ -239,6 +239,8 @@ DelayQuestMapClose |
 
 ## hudanimations.txt
 
+Animations which are not present in TF2 or are used in `hudanimations_tf` have been removed from this list
+
 Animation | Description
 --------- | -----------
 ShowCommentary | 
@@ -250,13 +252,14 @@ PulseOption4 |
 PulseOption5 | 
 HideVoteBackgrounds | 
 
-## Unused Animations
+## File-less animations
 
-Some of these may not function ingame or are inaccessible through normal means!
+These animations are not defined anywhere, and are only referenced in the code.
+It is possible that some of them cannot be triggered in game!
 
 Animation | Description
 --------- | -----------
-HintMessageLower | Potential remnants of HL2? used for the history of picked up weapons
+HintMessageLower | Potential remnants from HL2? used for the history of picked up weapons
 HintMessageRaise | Same as above
 HudReplayReminderIn | Potential remnant from when replays were enabled on valve servers?
 HudReplayReminderIn2 | Same as above

--- a/2-LISTS/Animlist.md
+++ b/2-LISTS/Animlist.md
@@ -241,73 +241,6 @@ DelayQuestMapClose |
 
 Animation | Description
 --------- | -----------
-LevelInit | 
-WeaponHighlight | 
-OpenWeaponSelectionMenu | 
-CloseWeaponSelectionMenu | 
-FadeOutWeaponSelectionMenu | 
-SuitAuxPowerMax | 
-SuitAuxPowerNotMax | 
-SuitAuxPowerDecreasedBelow25 | 
-SuitAuxPowerIncreasedAbove25 | 
-SuitAuxPowerNoItemsActive | 
-SuitAuxPowerOneItemActive | 
-SuitAuxPowerTwoItemsActive | 
-SuitAuxPowerThreeItemsActive | 
-SuitFlashlightOn | 
-SuitFlashlightOff | 
-HudTakeDamageFront | 
-HudTakeDamageLeft | 
-HudTakeDamageRight | 
-HudTakeDamageBehind | 
-HudTakeDamageHighLeft | 
-HudTakeDamageHighRight | 
-HudTakeDamageHigh | 
-HudTakeDamageDrown | 
-HudTakeDamagePoison | 
-HudTakeDamageBurn | 
-HudTakeDamageRadiation | 
-HudPlayerDeath | 
-HealthIncreasedAbove20 | 
-HealthIncreasedBelow20 | 
-SuitPowerIncreasedAbove20 | 
-SuitPowerIncreasedBelow20 | 
-SuitPowerZero | 
-TestMovement | 
-HealthDamageTaken | 
-SuitDamageTaken | 
-HealthLow | 
-HealthPulse | 
-HealthLoop | 
-SuitArmorLow | 
-SuitPulse | 
-SuitLoop | 
-AmmoIncreased | 
-AmmoDecreased | 
-AmmoEmpty | 
-Ammo2Increased | 
-Ammo2Decreased | 
-Ammo2Empty | 
-AmmoSecondaryIncreased | 
-AmmoSecondaryDecreased | 
-AmmoSecondaryEmpty | 
-WeaponChanged | 
-WeaponUsesSecondaryAmmo | 
-WeaponDoesNotUseSecondaryAmmo | 
-CraneMagnetFlash | 
-HintMessageShow | 
-HintMessageHide | 
-KeyHintMessageShow | 
-KeyHintMessageHide | 
-SquadMemberAdded | 
-SquadMemberLeft | 
-SquadMemberDied | 
-SquadMembersFollowing | 
-SquadMembersStationed | 
-PoisonDamageTaken | 
-PoisonDamageCured | 
-PoisonPulse | 
-PoisonLoop | 
 ShowCommentary | 
 HideCommentary | 
 PulseOption1 | 
@@ -316,3 +249,17 @@ PulseOption3 |
 PulseOption4 | 
 PulseOption5 | 
 HideVoteBackgrounds | 
+
+## Unused Animations
+
+Some of these may not function ingame or are inaccessible through normal means!
+
+Animation | Description
+--------- | -----------
+HintMessageLower |
+HintMessageRaise |
+HudReplayReminderIn |
+HudReplayReminderIn2 |
+eventHudCartAlarmPulseStop |
+HudTournament_DoorsCloseEndRound | runs if "competitive_victory" is the current Tournament mode state
+TimerFlash |


### PR DESCRIPTION
Right now this is a draft PR because i'm not sure this is the best way to go about this.
I've removed all of the HL2 animations which are not in the game, as well as the ones which are also in `hudanimations_tf`.
I've also added a couple of potentially unused animations which _are_ in the game.

`HudReplayReminderIn` and `HudReplayReminderIn2` might be a remnant from when replays were enabled on valve servers? I'm not entirely sure of that though

I assumed that `TimerFlash` may have been superseded by `TimerIncrement` and `TimerDecrement`, But it actually appears that `TimerIncrement` and `TimerDecrement` do not even exist!
I haven't changed anything about them being mentioned yet, but i think maybe its a remnant of Pre-matchhud TF2, as I seem to remember the timer flashing when you capture a point, although i haven't been able to find any footage of it

`HintMessageLower` and `HintMessageRaise` appear to be remnants of HL2, specifically the part of the hud which shows a history of what items you've picked up. This may not work at all in TF2

`eventHudCartAlarmPulseStop` (the camelcase is intentional) appears to be a misspelling of `HudCartAlarmPulseStop`, as the latter doesn't exist! this is never noticeable in game because the same code that calls this animation also sets the visibility of the panel itself to false. seems like someone might've copied the name of the animation from `hudanimations_tf` and accidentally removed the space between `event` and `HudCartAlarmPulseStop`.
I've already emailed Valve about this, but i'm not entirely sure they'll ever fix it since its not visible in game and 1 animation always running probably is not super performance intensive.