### PR TITLE
Update charge bars in filelist

### DIFF
--- a/2-LISTS/Filelist.md
+++ b/2-LISTS/Filelist.md
@@ -137,7 +137,7 @@ huditemeffectmeter.res | **Charge meter for:  Sandman / Wrap Assassin / Sandvich
 huditemeffectmeter_cleaver.res | **Charge meter for: Flying Guillotine**
 huditemeffectmeter_demoman.res | **Counter for: Eyelander heads and AirStrike**
 huditemeffectmeter_engineer.res | **Counter for: Frontier Justice and Manmelter**
-huditemeffectmeter_halloweensouls.res | **Counter for: Halloween souls collected**
+huditemeffectmeter_halloweensouls.res | *No longer in use*
 huditemeffectmeter_heavy.res | **Charge meter for: Heavy rage in MvM**
 huditemeffectmeter_kartcharge.res | **Charge meter for: Halloween Karts**
 huditemeffectmeter_killstreak.res | **Counter for: killstreak weapons**


### PR DESCRIPTION
Mad milk, Cleaner's Carbine, and Razorback weren't listed before, now they are!

Also marked `huditemeffectmeter_halloweensouls.res` as no longer in use, I don't know if it was in use before, but I can't find a reference to it in the strings of the current game DLLs, and its commented out in the code we have access to.