### PR TITLE
Update to latest hud version (Dec 14 2022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 * Master list of all files: [here](/2-LISTS/Filelist.md)
 * Master list of all animations: [here](/2-LISTS/Animlist.md)
-* Default hud files: [here](reference) [Last updated 2022/8/11]
+* Default hud files: [here](reference) [Last updated 2022/12/14]
 * Statistics about hud files: [here](/2-LISTS/Statlist.md)
 
 ## Tutorial Section

--- a/reference/resource/ui/econ/itempickuppanel.res
+++ b/reference/resource/ui/econ/itempickuppanel.res
@@ -38,8 +38,8 @@
 			"model_wide"	"240"
 			
 			"text_forcesize"	"1"
-			"text_xpos"		"250"
-			"text_wide"		"225"
+			"text_xpos"		"245"
+			"text_wide"		"230"
 			"text_center"	"1"
 			"is_mouseover"		"1"
 			"hide_collection_panel" "1"

--- a/reference/resource/ui/hudmannvsmachinestatus.res
+++ b/reference/resource/ui/hudmannvsmachinestatus.res
@@ -43,20 +43,6 @@
 		"pin_corner_to_sibling"        "4"          
 		"pin_to_sibling_corner"        "6"  
 	}
-
-	"CurrencyStatusPanel"
-	{
-		"ControlName"		"CCurrencyStatusPanel"
-		"fieldName"			"CurrencyStatusPanel"
-		"xpos"				"0"
-		"ypos"				"r100"
-		"wide"				"100"
-		"tall"				"100"
-		"xpos_minmode"		"65"
-		"ypos_minmode"		"r88"
-		"visible" 			"1"
-		"enabled" 			"1"
-	}
 	
 	"InWorldCurrencyPanel"
 	{

--- a/reference/resource/ui/mainmenuoverride.res
+++ b/reference/resource/ui/mainmenuoverride.res
@@ -1707,27 +1707,77 @@
 				{
 					"0"
 					{
-						"item"		"Summer 2022 Cosmetic Key"
+						"item"		"Winter 2022 Cosmetic Key"
 						"show_market"	"0"
 					}
 					"1"
 					{
-						"item"		"Summer 2022 Cosmetic Case"
+						"item"		"Winter 2022 Cosmetic Case"
 						"show_market"	"1"
-					}
-					"2"
-					{
-						"item"		"Taunt: Doctor's Defibrillators"
-						"show_market"	"0"
-					}
-					"3"
-					{
-						"item"		"Taunt: Shooter's Stakeout"
-						"show_market"	"0"
 					}
 					"4"
 					{
-						"item"		"Taunt: The Hot Wheeler"
+						"item"		"Taunt: Russian Rubdown"
+						"show_market"	"0"
+					}
+					"5"
+					{
+						"item"		"Taunt: Tailored Terminal"
+						"show_market"	"0"
+					}
+					"6"
+					{
+						"item"		"Taunt: Roasty Toasty"
+						"show_market"	"0"
+					}
+					"7"
+					{
+						"item"		"Map Token Frostwatch"
+						"show_market"	"0"
+					}
+					"8"
+					{
+						"item"		"Map Token Frostcliff"
+						"show_market"	"0"
+					}
+					"9"
+					{
+						"item"		"Map Token Rumford"
+						"show_market"	"0"
+					}
+					"10"
+					{
+						"item"		"Map Token Frosty"
+						"show_market"	"0"
+					}
+					"11"
+					{
+						"item"		"Map Token Coal Pit"
+						"show_market"	"0"
+					}
+					"12"
+					{
+						"item"		"Strange Filter: Frostwatch (Community)"
+						"show_market"	"0"
+					}
+					"13"
+					{
+						"item"		"Strange Filter: Frostcliff (Community)"
+						"show_market"	"0"
+					}
+					"14"
+					{
+						"item"		"Strange Filter: Rumford (Community)"
+						"show_market"	"0"
+					}
+					"15"
+					{
+						"item"		"Strange Filter: Frosty (Community)"
+						"show_market"	"0"
+					}
+					"16"
+					{
+						"item"		"Strange Filter: Coal Pit (Community)"
 						"show_market"	"0"
 					}
 				}

--- a/reference/resource/ui/mvmcriteria.res
+++ b/reference/resource/ui/mvmcriteria.res
@@ -167,10 +167,10 @@
 			"scaleImage"	"1"
 		}
 
-		"ToorLootTitle"
+		"TourLootTitle"
 		{
 			"ControlName"	"Label"
-			"fieldName"		"ToorLootTitle"
+			"fieldName"		"TourLootTitle"
 			"font"			"HudFontSmallBold"
 			"labelText"		"#TF_MvM_TourLootTitle"
 			"textAlignment"	"west"
@@ -181,10 +181,10 @@
 			"tall"			"30"
 		}
 
-		"ToorLootDetailLabel"
+		"TourLootDetailLabel"
 		{
 			"ControlName"	"Label"
-			"fieldName"		"ToorLootDetailLabel"
+			"fieldName"		"TourLootDetailLabel"
 			"font"			"HudFontSmall"
 			"labelText"		"%tour_loot_detail%"
 			"textAlignment"	"west"
@@ -193,7 +193,7 @@
 			"ypos"			"30"
 			"zpos"			"0"
 			"wide"			"280"
-			"tall"			"50"
+			"tall"			"85"
 		}
 	}
 

--- a/reference/scripts/hudlayout.res
+++ b/reference/scripts/hudlayout.res
@@ -355,6 +355,22 @@
 		"PaintBackgroundType"	"2"
 	}
 	
+	"CurrencyStatusPanel"
+	{
+		"ControlName"		"CCurrencyStatusPanel"
+		"fieldName"			"CurrencyStatusPanel"
+		"xpos"				"0"
+		"ypos"				"r100"
+		"wide"				"100"
+		"tall"				"100"
+		"xpos_minmode"		"65"
+		"ypos_minmode"		"r88"
+		"visible" 			"0"
+		"enabled" 			"1"
+		
+		"PaintBackgroundType"	"2"
+	}
+	
 	HudProgressBar
 	{
 		"fieldName" "HudProgressBar"


### PR DESCRIPTION
Features updates:
Sep 26 2022 - "Fixed clipped text in the Mann vs. Machine loot list screen" (changed text_xpos from 250 to 245 and text_wide from 225 to 230), (No change note) fixed misspelled panels ToorLootTitle and ToorLootDetailLabel to be "Tour" instead in mvmcriteria.res, also increased tall of TourLootDetailLabel from 50 to 85
Dec 6 2022 - (No change note) Updated store items shown on the main menu 
Dec 7 2022 - (No change note) Moved CurrencyStatusPanel from hudmannvsmachinestatus.res to hudlayout.res (done for vscript reasons)