### PR TITLE
Add doodlesstuff archive link

### DIFF
--- a/2-LISTS/OtherTutorials.md
+++ b/2-LISTS/OtherTutorials.md
@@ -4,6 +4,7 @@ This section includes other hud editing tutorials and references to use. This is
 
 ## General Hud Editing
 
+* Doodlestuff (incomplete archive):  https://web.archive.org/web/20230129110452/http://doodlesstuff.com/?p=tf2hud
 * Rays' video tutorials: https://www.youtube.com/playlist?list=PL5eNrB8RrXXuV3P1nv6NnwF-tCL_KnJIs
 * Hypnotize's hud updating tutorial: https://github.com/Hypnootize/Huds-Update-Guide
 


### PR DESCRIPTION
The site is still down, and it seems no one has a complete archive. This has all of the basic tutorials, but none of the more "advanced" information.